### PR TITLE
fixed muliple definition error

### DIFF
--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -27,8 +27,8 @@ struct vlc_kbd_key_t {
 };
 
 // An array of the key codes used for setting a single key color
-const struct vlc_kbd_key_t vlc_kcolor_keys[111];
-const size_t vlc_keys_sz;
+extern const struct vlc_kbd_key_t vlc_kcolor_keys[111];
+extern const size_t vlc_keys_sz;
 
 // Keymapping struct
 // Mapping the keys is performed all at once, thus such a big struct


### PR DESCRIPTION
While trying to compile I've got error:

```cc build/util.o build/config.o build/fmt.o build/daemon.o build/keyboard.o -Wall -Wpedantic -lusb-1.0 -I/usr/include/libusb-1.0 -Wno-unused-result -Wno-format-overflow -O3 -o bin/volcanod
/usr/bin/ld: build/keyboard.o:(.data.rel.ro.local+0x0): multiple definition of `vlc_kcolor_keys'; build/daemon.o:(.rodata+0x60): first defined here
/usr/bin/ld: build/keyboard.o:(.rodata+0x0): multiple definition of `vlc_keys_sz'; build/daemon.o:(.rodata+0x58): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:26: volcanod] Error 1
```

I've fixed it by adding `extern` keyword to problematic declarations.

#### Appeared on:
Ubuntu 22.04.1
gcc 11.3.0
